### PR TITLE
feat: added customization for control server api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ gluebot:
 ### Environment options:
 
 ```
-API_KEY=                # optional, but required for secured gluetun API.
-CONTROL_SERVER_PORT=    # optional. defaults to 8000.
-RESTART_TIME=           # optional, but required for timed restarts.
-TZ=                     # optional. defaults to UTC.
+API_KEY=                	# optional, but required for secured gluetun API.
+CONTROL_SERVER_PORT=    	# optional. defaults to `8000`
+CONTROL_SERVER_ENDPOINT=   # optional. defaults to `/v1/openvpn/status`.
+RESTART_TIME=           	# optional, but required for timed restarts.
+TZ=                     	# optional. defaults to UTC.
 ```
 
 ### Basic timed restart without API auth:
@@ -62,7 +63,7 @@ TZ=                     # optional. defaults to UTC.
 ```
 
 
-### Timed restart with API auth, and gluetun api on port 9090:
+### Timed restart with API auth, and gluetun api on port 9090 and latest api endpoint:
 ```
   gluebot:
     container_name: gluebot
@@ -72,6 +73,7 @@ TZ=                     # optional. defaults to UTC.
       - RESTART_TIME=19:10
       - TZ=Europe/London
       - CONTROL_SERVER_PORT=9090
+		- CONTROL_SERVER_ENDPOINT=/v1/vpn/status
     network_mode: "service:gluetun"
     restart: unless-stopped
 ```

--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ gluebot:
 
 ### Environment options:
 
-```
-API_KEY=                	# optional, but required for secured gluetun API.
-CONTROL_SERVER_PORT=    	# optional. defaults to `8000`
-CONTROL_SERVER_ENDPOINT=   # optional. defaults to `/v1/openvpn/status`.
-RESTART_TIME=           	# optional, but required for timed restarts.
-TZ=                     	# optional. defaults to UTC.
-```
+| Variable | Default / Requirement | Description |
+| :--- | :--- | :--- |
+| **API_KEY** | Optional | Required only if your Gluetun API is secured with authentication. |
+| **CONTROL_SERVER_PORT** | `8000` | The port Gluetun uses for its internal HTTP control server. |
+| **CONTROL_SERVER_ENDPOINT** | `/v1/openvpn/status` | The API path used to check/reset the connection. This has recently changed to `/v1/vpn/status` |
+| **RESTART_TIME** | Optional | Required if you want to force a restart at a specific time regardless of speed. |
+| **TZ** | `UTC` | Set this to your local timezone (e.g., `Europe/Amsterdam`). |
+
 
 ### Basic timed restart without API auth:
 ```

--- a/gluebot.py
+++ b/gluebot.py
@@ -14,6 +14,7 @@ import threading
 CONTROL_SERVER_PORT = os.environ.get('CONTROL_SERVER_PORT')
 API_KEY = os.environ.get('API_KEY')
 RESTART_TIME = os.environ.get('RESTART_TIME')
+CONTROL_SERVER_ENDPOINT = os.environ.get('CONTROL_SERVER_ENDPOINT', '/v1/openvpn/status')
 
 if not CONTROL_SERVER_PORT:
     raise ValueError("CONTROL_SERVER_PORT must be set")
@@ -22,7 +23,7 @@ app = Flask(__name__)
 # Apply the ProxyFix middleware to correctly capture the client's real IP address
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1)
 
-API_URL = f'http://127.0.0.1:{CONTROL_SERVER_PORT}/v1/openvpn/status'
+API_URL = f'http://127.0.0.1:{CONTROL_SERVER_PORT}${CONTROL_SERVER_ENDPOINT}'
 DATA = {
     'status': 'stopped'
 }


### PR DESCRIPTION
Based on the recent documentation, the api endpoint for gluetun is `/v1/vpn/status` (see: [https://github.com/qdm12/gluetun-wiki/blob/4a68196351760adbb6bb8cd3d4bd588e92221b67/setup/advanced/control-server.md](https://github.com/qdm12/gluetun-wiki/blob/4a68196351760adbb6bb8cd3d4bd588e92221b67/setup/advanced/control-server.md))

I have added an optional new env variable `CONTROL_SERVER_ENDPOINT` which defaults to the original value, allows overrides to adjust to the latest harmonized API endpoint of gluetun